### PR TITLE
Ente daffy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG ICON="cube"
 # ==================================================>
 # ==> Do not change the code below this line
 ARG ARCH=arm32v7
-ARG DISTRO=ente
+ARG DISTRO=daffy
 ARG BASE_TAG=${DISTRO}-${ARCH}
 ARG BASE_IMAGE=dt-ros-commons
 ARG LAUNCHER=default

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG ICON="cube"
 # ==================================================>
 # ==> Do not change the code below this line
 ARG ARCH=arm32v7
-ARG DISTRO=daffy
+ARG DISTRO=ente
 ARG BASE_TAG=${DISTRO}-${ARCH}
 ARG BASE_IMAGE=dt-ros-commons
 ARG LAUNCHER=default
@@ -49,10 +49,6 @@ ENV DT_LAUNCHER "${LAUNCHER}"
 # install apt dependencies
 COPY ./dependencies-apt.txt "${REPO_PATH}/"
 RUN dt-apt-install ${REPO_PATH}/dependencies-apt.txt
-
-# install python dependencies
-COPY ./dependencies-py.txt "${REPO_PATH}/"
-RUN pip install -r ${REPO_PATH}/dependencies-py.txt
 
 # install python3 dependencies
 COPY ./dependencies-py3.txt "${REPO_PATH}/"

--- a/dependencies-py.txt
+++ b/dependencies-py.txt
@@ -1,3 +1,0 @@
-# LIST YOUR PYTHON PACKAGES HERE
-zuper-nodes-python2-z5
-cbor2==4.1.2

--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -1,3 +1,3 @@
 # LIST YOUR PYTHON3 PACKAGES HERE
-zuper-nodes-z5
+zuper-nodes-z6
 cbor2==4.1.2

--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -1,1 +1,3 @@
 # LIST YOUR PYTHON3 PACKAGES HERE
+zuper-nodes-z5
+cbor2==4.1.2

--- a/packages/duckiebot_fifos_bridge/src/duckiebot_fifos_bridge_node.py
+++ b/packages/duckiebot_fifos_bridge/src/duckiebot_fifos_bridge_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import logging
 import signal

--- a/packages/duckiebot_fifos_bridge/src/duckiebot_fifos_bridge_node.py
+++ b/packages/duckiebot_fifos_bridge/src/duckiebot_fifos_bridge_node.py
@@ -24,8 +24,8 @@ class DuckiebotBridge(object):
         AIDONODE_DATA_OUT = '/fifos/agent-out'
         logger.info('DuckiebotBridge starting communicating with the agent.')
         self.ci = ComponentInterface(AIDONODE_DATA_IN, AIDONODE_DATA_OUT, 'agent', timeout=30)
-        self.ci.write_topic_and_expect_zero(u'seed', 32)
-        self.ci.write_topic_and_expect_zero(u'episode_start', {u'episode_name': u'episode'})
+        self.ci.write_topic_and_expect_zero('seed', 32)
+        self.ci.write_topic_and_expect_zero('episode_start', {'episode_name': 'episode'})
         logger.info('DuckiebotBridge successfully sent to the agent the seed and episode name.')
         self.client = ROSClient()
         logger.info('DuckiebotBridge has created ROSClient.')
@@ -60,10 +60,10 @@ class DuckiebotBridge(object):
             if nimages_received == 0:
                 logger.info('DuckiebotBridge got the first image from ROS.')
 
-            obs = {u'camera': {u'jpg_data': data}}
-            self.ci.write_topic_and_expect_zero(u'observations', obs)
-            commands = self.ci.write_topic_and_expect(u'get_commands', expect=u'commands')
-            commands = commands.data[u'wheels']
+            obs = {'camera': {'jpg_data': data}}
+            self.ci.write_topic_and_expect_zero('observations', obs)
+            commands = self.ci.write_topic_and_expect('get_commands', expect='commands')
+            commands = commands.data['wheels']
 
             self.client.send_commands(commands)
             if nimages_received == 0:


### PR DESCRIPTION
The ente includes the following changes:

Uses ubuntu 20.04
Uses python 3.8
Uses ros noetic
Updates the code using 2to3 and/or manual inspection
This mostly includes fixing relative imports broken in py3 and print statements without parenthesis
Update dependencies to be py3 compatible

The ente-daffy branche has the daffy tag instead of ente to be merge-ready